### PR TITLE
Squash messy workflow test commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from `dotnet new gitignore`
 
+# dotnet releaser
+artifacts-dotnet-releaser/
+
 # dotenv files
 .env
 

--- a/Source/ASTRedux.csproj
+++ b/Source/ASTRedux.csproj
@@ -23,4 +23,9 @@
     <BaseIntermediateOutputPath>../obj/</BaseIntermediateOutputPath>
   </PropertyGroup>
   
+  <!--Might not be necessary anymore. I don't even think this worked-->
+  <PropertyGroup>
+	<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+  
 </Project>


### PR DESCRIPTION
The workflow didn't work at all and dotnet-releaser was unsuitable for my needs, so I scrapped it entirely and am rebasing on the first commit. There was 15 commits total, but the last commit was deleting the workflow files. This looks like it doesn't do much, but this is just rewriting the messy history that is irrelevant to the overall status of the repository.